### PR TITLE
Update friend list command test and friend command test

### DIFF
--- a/src/main/java/seedu/address/logic/commands/friends/ListFriendCommand.java
+++ b/src/main/java/seedu/address/logic/commands/friends/ListFriendCommand.java
@@ -44,14 +44,7 @@ public class ListFriendCommand extends Command {
             FriendIdContainsKeywordPredicate friendIdContainsKeywordPredicate =
                     (FriendIdContainsKeywordPredicate) predicate;
             model.updateFilteredFriendsList(friendIdContainsKeywordPredicate);
-            //TODO: get the actual friend being listed if only one friend
-            if (model.getFilteredFriendsList().size() == 1) {
-                return new CommandResult(getMessageSuccess(), CommandType.FRIEND_GET,
-                        model.getFilteredFriendsList().get(0));
-            } else {
-                return new CommandResult(getMessageSuccess(), CommandType.FRIEND_LIST);
-            }
-
+            return new CommandResult(getMessageSuccess(), CommandType.FRIEND_LIST);
         }
         // ListCommand initialized with unknown predicate
         throw new CommandException(MESSAGE_UNKNOWN_PREDICATE);
@@ -62,7 +55,7 @@ public class ListFriendCommand extends Command {
      *
      * @return String containing success message
      */
-    public String getMessageSuccess() {
+    public String getMessageSuccess() throws CommandException {
         if (predicate instanceof FriendIdContainsKeywordPredicate) {
             FriendIdContainsKeywordPredicate friendIdContainsKeywordPredicate =
                     (FriendIdContainsKeywordPredicate) predicate;
@@ -72,7 +65,7 @@ public class ListFriendCommand extends Command {
                     : " whose id contains the keyword: " + keyword;
             return String.format(MESSAGE_SUCCESS_PREPEND, FRIEND_LIST) + messageEnd;
         }
-        return String.format(MESSAGE_SUCCESS_PREPEND, FRIEND_LIST);
+        throw new CommandException(MESSAGE_UNKNOWN_PREDICATE);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ListFriendCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListFriendCommandTest.java
@@ -1,16 +1,25 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.friends.ListFriendCommand.MESSAGE_UNKNOWN_PREDICATE;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalFriends.getTypicalFriendsList;
 import static seedu.address.testutil.TypicalGames.getTypicalGamesList;
+
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.friends.ListFriendCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.friend.Friend;
 import seedu.address.model.friend.FriendIdContainsKeywordPredicate;
 
 /**
@@ -28,19 +37,42 @@ public class ListFriendCommandTest {
     }
 
     @Test
+    public void execute_unknownPredicate_throwsCommandException() {
+        Predicate<Friend> unknownPredicate = friend -> false;
+        assertCommandFailure(new ListFriendCommand(unknownPredicate), model, MESSAGE_UNKNOWN_PREDICATE);
+        assertThrows(CommandException.class, () -> new ListFriendCommand(unknownPredicate).getMessageSuccess());
+    }
+
+    @Test
     public void execute_listFriendNotFiltered_showsSameList() {
         assertCommandSuccess(new ListFriendCommand(preparePredicate("")), model,
                 String.format(ListFriendCommand.MESSAGE_SUCCESS_PREPEND, ListFriendCommand.FRIEND_LIST), expectedModel);
     }
 
     @Test
-    public void execute_listFriendIsFiltered_showsEverything() {
+    public void execute_listFriendIsFiltered_showsEverything() throws CommandException {
         // Set up expected filtered list by Ali
         expectedModel.updateFilteredFriendsList(preparePredicate("Ali"));
 
         ListFriendCommand listFriendCommand = new ListFriendCommand(preparePredicate("Ali"));
         assertCommandSuccess(listFriendCommand, model,
                 listFriendCommand.getMessageSuccess(), expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        Predicate<Friend> filterByA = preparePredicate("A");
+        ListFriendCommand friendCommand = new ListFriendCommand(filterByA);
+
+        // Same Object
+        assertTrue(friendCommand.equals(friendCommand));
+        // Same Predicate
+        assertTrue(friendCommand.equals(new ListFriendCommand(filterByA)));
+        // Same Predicate Value
+        assertTrue(friendCommand.equals(new ListFriendCommand(preparePredicate("A"))));
+
+        // Different Value
+        assertFalse(friendCommand.equals(new ListFriendCommand(preparePredicate("Different"))));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/friends/FriendCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/friends/FriendCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser.friends;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+class FriendCommandParserTest {
+
+    private FriendCommandParser parser = new FriendCommandParser();
+
+    @Test
+    public void parse_invalidFlag_exceptionThrown() {
+        // unrecognised flag
+        assertThrows(ParseException.class, () -> parser.parse(" --invalid"));
+        // empty input
+        assertThrows(ParseException.class, () -> parser.parse(""));
+    }
+
+    @Test
+    public void parse_validFlag_success() throws ParseException {
+        // list friend flag
+        String input = " --list";
+        assertEquals(parser.parse(input), new ListFriendCommandParser().parse(input));
+        // TODO add tests for add, delete and get when all are complete
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/friends/ListFriendCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/friends/ListFriendCommandParserTest.java
@@ -1,11 +1,10 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.friends;
 
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.friends.ListFriendCommand;
-import seedu.address.logic.parser.friends.ListFriendCommandParser;
 import seedu.address.model.friend.FriendIdContainsKeywordPredicate;
 
 public class ListFriendCommandParserTest {
@@ -23,25 +22,16 @@ public class ListFriendCommandParserTest {
     @Test
     public void parse_validArgs_returnsListCommand() {
         // filter by friend and keyword test
-        String userInput = " --friend test";
+        String userInput = " --list test";
         String expectedParsedKeyword = "test";
         ListFriendCommand expectedListFriendCommand =
                 new ListFriendCommand(new FriendIdContainsKeywordPredicate(expectedParsedKeyword));
-        // TODO Update after list command is updated
-        // assertParseSuccess(parser, userInput, expectedListFriendCommand);
-
-        // with friend filter but without keyword (defaults to list all friends)
-
-        // userInput = " --friend";
-        // expectedListFriendCommand = new ListFriendCommand(new FriendIdContainsKeywordPredicate(""));
-        // assertParseSuccess(parser, userInput, expectedListFriendCommand);
-
-        // without friend filter (defaults to friend) but with keyword test
-        userInput = "test";
-        expectedListFriendCommand = new ListFriendCommand(new FriendIdContainsKeywordPredicate("test"));
         assertParseSuccess(parser, userInput, expectedListFriendCommand);
 
-
+        // with friend filter but without keyword (defaults to list all friends)
+        userInput = " --list";
+        expectedListFriendCommand = new ListFriendCommand(new FriendIdContainsKeywordPredicate(""));
+        assertParseSuccess(parser, userInput, expectedListFriendCommand);
     }
 
 }


### PR DESCRIPTION
Changes:
* Update friend list command and its tests for new syntax
* Achieved 100% coverage for relevant friend list command and parser
Note: I will be making a separate PR for the `FriendsListParserTest` and `GamesListParserTest` as they require all the other PRs to be merged in first before they can be tested

Issues:
* Resolves #62 

Tests:
* Run with coverage to verify test coverage has increased